### PR TITLE
Add topojson's clockwise and filter post-processing steps

### DIFF
--- a/server.js
+++ b/server.js
@@ -51,7 +51,12 @@ app.post("/",
       }
     }
     
-    var topology = topojson.topology(data, buildOptions(request));
+    var options = buildOptions(request);
+    var topology = topojson.topology(data, options);
+    if ("force-clockwise" in request.query) {
+      topojson.clockwise(topology, options);
+    }
+    topojson.filter(topology, options);
     response.json(topology);
   });
 


### PR DESCRIPTION
It turns out that there are a couple post processing steps that you should run after converting to a topology to clean things up and get good TopoJSON out the other end. Now we run those. There are a few additional options `filter` can take, which can be added later if necessary.

This should also fix the issues in Charlotte’s zoning data.
